### PR TITLE
Improve GBM realism for retirement drawdown simulation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bin/rubocop"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/inputs.yml.template
+++ b/inputs.yml.template
@@ -21,25 +21,66 @@ province_code: ONT
 # Supports fractional, eg: 1.5
 success_factor: 1
 
-# Growth rate average, min, and max to generate variability
-# Enter the "real" return rather than nominal as inflation isn't handled currently.
-# For example if you're invested in broad market index funds or ETF's and using
-# an average return of 8%, but inflation is around 3%, then put 5% real return here.
-# The min and max are to constrain volatility. For example the market has dropped
-# by 30% and has grown by that much as well.
-# Set a downturn_threshold so if market return is below this amount, use cash_cushion.
-# Set savings to the interest rate you're earning on your cash cushion.
+# Growth rate settings for your portfolio.
+# Enter "real" returns (i.e. after subtracting inflation), not nominal returns.
+# For example: if your investments historically return 8% but inflation is 3%, enter 0.05.
+#
+# average: the long-run average annual real return you expect from your portfolio.
+#   Broad global equity index funds (e.g. XEQT, VEQT): ~0.05 to 0.07
+#   Balanced 60/40 portfolio: ~0.03 to 0.05
+#
+# min and max: the historical extreme annual returns for your investment type.
+#   These are NOT a typical range — they represent the worst and best single years
+#   ever recorded. The simulation uses them to calibrate how volatile your returns are.
+#   Setting them too narrow makes the simulation unrealistically calm.
+#
+#   100% global equity (e.g. XEQT, VEQT — all stocks, no bonds):
+#     average: 0.05 to 0.07
+#     min: -0.40  (a globally diversified portfolio fell ~40% in 2008; -45% figures
+#                  are for US-only equities in 1931, less relevant to modern global funds)
+#     max: 0.45   (best recorded calendar years for globally diversified equity)
+#   80/20 stocks/bonds (e.g. broadly diversified with US, Canada, international):
+#     average: 0.04 to 0.05
+#     min: -0.33  (bonds cushion the crash — a bad equity year becomes less severe)
+#     max: 0.38   (bonds also cap the upside in boom years)
+#   60/40 stocks/bonds (balanced portfolio):
+#     average: 0.03 to 0.04
+#     min: -0.25
+#     max: 0.35
+#
+# downturn_threshold: if the simulated return falls below this, the cash cushion is used
+#   instead of selling investments at a loss. Set to 0 to disable.
+# savings: the annual interest rate you earn on your cash cushion (e.g. HISA or GIC rate).
 annual_growth_rate:
   average: 0.05
-  min: -0.3
-  max: 0.3
+  min: -0.40
+  max: 0.45
   downturn_threshold: -0.1
   savings: 0.005
 
 # Choose the return sequence generator: mean, geometric_brownian_motion, constant
 # If using `success_rate` mode, then choose either `mean` or `geometric_brownian_motion`
-# `constant` returns are conceptually easy to understand, and produce pleasing predictable results,
-# but are unrealistic as the market doesn't actually do this.
+#
+# `constant`: every year returns exactly the average. Easy to understand and produces
+#   clean, predictable results, but completely unrealistic — markets don't do this.
+#
+# `mean`: returns are random each year but always average out to exactly your target
+#   over the full simulation. Useful for understanding the model, but still unrealistic
+#   because real retirement outcomes are sensitive to the *order* of good and bad years,
+#   not just the average.
+#
+# `geometric_brownian_motion`: each year gets a realistic random return — mostly near
+#   the average, with occasional good and bad years, including rare severe crashes.
+#   This is the most realistic option and the recommended choice for success_rate mode.
+#
+#   Important caveat: this model will produce more conservative (lower) success rates
+#   than you might expect from published research like the "4% rule" or the
+#   "2.7% global safe withdrawal rate". That's intentional — the model is designed to
+#   stress-test your plan against scenarios that could be worse than anything in the
+#   historical record. Real markets tend to recover after crashes (mean reversion),
+#   but this model does not simulate that — every year is drawn independently.
+#   Think of it as: "if the future is somewhat worse than history, will my plan survive?"
+#   rather than: "how often has this worked historically?"
 return_sequence_type: geometric_brownian_motion
 
 # Optionally continue to make TFSA contributions during RRSP and Taxable drawdown phases

--- a/lib/return_sequences/geometric_brownian_motion_sequence.rb
+++ b/lib/return_sequences/geometric_brownian_motion_sequence.rb
@@ -1,23 +1,86 @@
 # frozen_string_literal: true
 
 module ReturnSequences
-  # Generate a sequence of returns for ages between `@start_age` and `@max_age`
-  # using a Geometric Brownian Motion (GBM) model.
-  # Returns are calculated based on a drift term (`@avg`),
-  # and a volatility term (`sigma`), with random shocks (`z`) introduced at each age.
-  # The resulting sequence is returned as a hash with age as the key and return as the value.
-  # https://www.columbia.edu/~ks20/FE-Notes/4700-07-Notes-GBM.pdf
-  # https://medium.com/@polanitzer/estimating-the-parameters-for-a-geometric-brownian-motion-stochastic-process-using-two-different-6c7cbdf20c8f
+  # Generates a sequence of annual portfolio returns using Geometric Brownian Motion (GBM).
+  #
+  # == The problem GBM solves
+  #
+  # A simple retirement simulator might assume your portfolio grows by a steady 5% every
+  # year. That produces clean, predictable charts — but it's not how markets actually work.
+  # Real markets lurch up and down: a great year, two bad years, another great year. The
+  # *order* of those ups and downs matters enormously in retirement, because you're selling
+  # investments to fund spending at the same time. A crash in year 2 of retirement is far
+  # more damaging than the same crash in year 20.
+  #
+  # GBM is a way of generating realistic-looking sequences of annual returns: mostly near
+  # the long-run average, but with genuine good years and bad years, including occasional
+  # severe crashes. Unlike using actual historical return data, GBM can produce sequences
+  # that have never happened before — useful for stress-testing a plan against futures
+  # worse than any we've seen.
+  #
+  # == Known limitation: no mean reversion
+  #
+  # Real markets tend to recover after crashes — cheap prices attract buyers, pushing
+  # returns back up. GBM does not model this. Every year is drawn independently, so
+  # the model can generate long strings of bad years with no corrective pull.
+  # This means GBM will produce lower success rates than historical studies (e.g.
+  # the "4% rule" research) for the same withdrawal rate, even with well-calibrated
+  # parameters. That is a deliberate trade-off: the goal is stress-testing against
+  # a future that could be worse than history, not reproducing historical outcomes.
+  #
+  # == How it works
+  #
+  # Each simulated year gets: long-run average return + a random shock.
+  # Most shocks are small; occasionally they're large (in either direction).
+  # The shocks are drawn from a Student-t distribution, which produces extreme years
+  # more often than a simple bell curve would — better matching how real markets behave.
+  #
+  # == Plain-English references
+  # - https://medium.com/the-quant-journey/a-gentle-introduction-to-geometric-brownian-motion-in-finance-68c37ba6f828
+  # - https://www.quantstart.com/articles/Geometric-Brownian-Motion/
   class GeometricBrownianMotionSequence < ReturnSequences::BaseSequence
+    # Controls how often extreme years occur in the simulation.
+    #
+    # Lower values = more frequent crashes and booms; higher values = closer to a
+    # normal bell curve where extreme years are rare.
+    #
+    # Why 10? Two competing concerns:
+    # - We want extreme years to be more common than a pure bell curve predicts,
+    #   because real markets do crash more often than the bell curve would suggest.
+    # - But we don't want to be so extreme that the simulation becomes incredible.
+    #   At df=5, a 2.58% withdrawal rate (considered ultra-conservative) showed only
+    #   80% success — implying 1-in-5 retirees would fail at that rate, which no
+    #   historical data supports.
+    #
+    # df=10 is a middle ground: crashes and booms happen a bit more often than a
+    # normal bell curve, but not so often that the results feel detached from reality.
+    # It also means the simulation can generate scenarios slightly worse than anything
+    # in the historical record — which is the whole point of using this approach rather
+    # than just replaying past data.
+    #
+    # See: https://en.wikipedia.org/wiki/Student%27s_t-distribution
+    DEGREES_OF_FREEDOM = 10
+
     protected
 
+    # For each year between start_age and max_age, draws a random shock (z) from a
+    # Student-t distribution and applies the GBM formula to produce an annual return.
+    #
+    # Key terms:
+    # - drift:  the average annual return converted to log-return form (e.g. 5% → log(1.05) ≈ 0.0488),
+    #           required because the formula works in log space.
+    # - sigma:  volatility — how wide the spread of annual returns is; higher = wilder swings.
+    # - z:      the random shock for the year (e.g. -1.3 or +0.8), representing how far
+    #           this particular year deviates from the average.
+    # - -(0.5 * sigma²): the Ito correction — without it, compounding maths would cause the
+    #           average of many simulated runs to drift above the intended average.
     def generate_returns
       sequence = {}
       drift    = Math.log(1 + @avg)
       sigma    = compute_sigma
 
       (@start_age..@max_age).each do |age|
-        z = rand_normal
+        z = rand_student_t(degrees_of_freedom: DEGREES_OF_FREEDOM)
         r = Math.exp(drift - (0.5 * (sigma**2)) + (sigma * z)) - 1
         sequence[age] = r.round(4)
       end
@@ -27,16 +90,49 @@ module ReturnSequences
 
     private
 
+    # Derives sigma (volatility) from the user's min/max inputs.
+    # Uses the statistical rule that ~99.7% of observations fall within
+    # ±3 standard deviations of the mean (the "three-sigma rule").
+    # The asymmetric max() picks whichever tail is wider, so an investment
+    # with a more extreme downside than upside (or vice versa) is handled correctly.
+    # For realistic results, min/max should represent the historical extreme annual
+    # returns for your investment type — not a comfortable or typical range.
     def compute_sigma
       deviation = [@max - @avg, @avg - @min].max
       deviation / 3.0
     end
 
+    # Generates a single random number from a standard normal distribution
+    # (bell curve centred at 0 with standard deviation 1) using the Box-Muller transform,
+    # which converts two uniform random numbers into a normally distributed one.
+    # See: https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
     def rand_normal(mean = 0.0, stddev = 1.0)
       u1 = rand
       u2 = rand
       z0 = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2 * Math::PI * u2)
       mean + (stddev * z0)
+    end
+
+    # Generates a single random number from a Student-t distribution.
+    #
+    # Why Student-t instead of normal? Real annual market returns have "fat tails" —
+    # extreme years (a -37% crash, a +50% boom) happen more often than a normal
+    # distribution would predict. If stock returns were truly normal, a crash as bad
+    # as 2008 would be expected roughly once every 10,000 years. In reality, we've
+    # seen many such events in the past century.
+    #
+    # Student-t has the same symmetric bell shape as normal, but with heavier tails:
+    # the lower the degrees_of_freedom, the more often extreme values occur.
+    # df=5 is commonly cited for *daily* stock returns, but annual returns are much
+    # closer to normal — using df=5 for annual data overcorrects significantly.
+    # df=10 produces mild fat tails appropriate for annual return modelling.
+    #
+    # Formula: t = Z / sqrt(V / df), where Z is a standard normal draw and
+    # V is a chi-squared draw (the sum of df squared standard normals).
+    def rand_student_t(degrees_of_freedom:)
+      z = rand_normal
+      v = Array.new(degrees_of_freedom) { rand_normal**2 }.sum
+      z / Math.sqrt(v / degrees_of_freedom)
     end
   end
 end

--- a/spec/lib/output/console_printer_spec.rb
+++ b/spec/lib/output/console_printer_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe Output::ConsolePrinter do
   end
 
   it "prints exactly the expected output without charts" do
+    # tty-table auto-detects terminal width and collapses to vertical layout when
+    # there is no real TTY (e.g. running tests from a tool or CI). Force a wide
+    # width so the spec produces consistent output regardless of environment.
+    allow(TTY::Screen).to receive(:width).and_return(200)
+
     simulation_output = Simulation::Simulator.new(app_config).run
     evaluator_results = Simulation::SimulationEvaluator.new(simulation_output[:yearly_results], app_config).evaluate
     first_year_cash_flow_results = FirstYearCashFlow.new(app_config).calculate


### PR DESCRIPTION
## Summary

- **Switch to Student-t distribution (df=10)** for random shocks in GBM, giving fatter tails so extreme years occur more realistically often. df=10 is appropriate for annual returns; the commonly cited df=5 is for daily returns and overcorrects significantly at annual timescales.
- **Recalibrate sigma** via updated `min`/`max` defaults in `inputs.yml.template`, with reference values per portfolio type (100% equity, 80/20, 60/40). Previous defaults produced sigma ~11.7%, well below the historical ~15% for globally diversified equity.
- **Document GBM's intentional pessimism**: the model produces lower success rates than historical studies (e.g. the "4% rule") because it draws each year independently with no mean reversion. This is by design — the goal is stress-testing against a future worse than history.
- **Rewrite all comments** in the GBM class for non-technical readers: plain-English explanations of drift, sigma, the Ito correction, Student-t, and degrees of freedom.
- **Fix a flaky spec** in `ConsolePrinter` that failed without a real TTY by stubbing `TTY::Screen.width`.
- **Add Claude Code project settings** with a post-edit rubocop hook.

## Test plan

- [ ] `bin/rubocop` passes clean
- [ ] `bin/rspec` — 113 examples, 0 failures
- [ ] Run `success_rate` mode with a conservative withdrawal rate (~2.5–3%) and confirm success rates are plausible for your portfolio type (see updated `inputs.yml.template` comments for reference values)
- [ ] Run `detailed` mode and confirm yearly results table renders correctly in a real terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)