### PR TITLE
[#44] Capture and replay failed return sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ inputs.yml
 my_inputs.yml
 scratch.md
 
+failed_runs/*
+!failed_runs/.gitkeep
+
 # AI assistants
 .claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Running the Simulation](#running-the-simulation)
   - [Sample Output](#sample-output)
   - [Determining Your Success Rate](#determining-your-success-rate)
+  - [Inspecting Why Scenarios Fail](#inspecting-why-scenarios-fail)
   - [Documentation](#documentation)
   - [Insights](#insights)
   - [Disclaimer](#disclaimer)
@@ -181,6 +182,44 @@ You control what "success" means via the `success_factor` setting in `inputs.yml
 
 > [!NOTE]
 > The 4% rule is often cited as having a "95% success rate" — but that figure comes from US historical data replayed over past sequences. This simulator uses Geometric Brownian Motion without mean reversion, intentionally modelling futures that could be worse than history. For the same 4% scenario, this simulator produces lower success rates. See [How It Works](docs/how-it-works.md#geometric_brownian_motion-recommended) for why, and [Is the 4% Rule Actually Safe?](docs/insights/four_percent_rule.md) for a detailed analysis of what this means in practice.
+
+## Inspecting Why Scenarios Fail
+
+A success rate of 85% answers *how often* a plan succeeds, but not *what the failures look like*. To make failures inspectable, every `success_rate` run captures a sample of the failed sequences to disk and produces a manifest. You can then replay any individual failure year-by-year with detailed mode.
+
+**1. Run success_rate mode** — produces a `failed_runs/` directory:
+
+```sh
+ruby main.rb success_rate
+```
+
+A reservoir of up to 50 failed runs is saved as `failed_runs/run_0001.yml`, `run_0002.yml`, … alongside an `index.md` summarising each one. The directory is wiped at the start of every `success_rate` run, so the contents always reflect the most recent invocation.
+
+**2. Open `failed_runs/index.md`** and pick an interesting failure:
+
+```
+- run_0001.yml — ran out at age 79, final balance $0
+- run_0002.yml — reached max_age 95 with $12,400 (below threshold $40,000)
+- run_0003.yml — ran out at age 84, final balance $0
+```
+
+**3. Edit `inputs.yml`** to point detailed mode at that file:
+
+```yaml
+return_sequence_type: recorded
+recorded_sequence_file: failed_runs/run_0001.yml
+```
+
+**4. Run detailed mode** — replays the captured sequence year by year:
+
+```sh
+ruby main.rb
+```
+
+Because the saved file stores only the return sequence (and a digest of the inputs that produced it), you can also pair a captured failure with *modified* inputs — for example, "replay this exact bad sequence, but with $35,000 spending instead of $40,000". When the digest no longer matches, you'll see a one-line note on startup; the run itself is not blocked, since the mismatch is the experiment.
+
+> [!WARNING]
+> `failed_runs/` contains a digest of your inputs and a year-by-year balance trajectory — same sensitivity class as `inputs.yml`. The directory is gitignored. If you want to preserve a particular failure across `success_rate` runs, copy it somewhere outside `failed_runs/` first; the next run will wipe and regenerate the directory.
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,10 +14,12 @@ lib/
   simulation/             # Core simulation loop and success evaluator
   strategy/               # Withdrawal planning and account selection
   tax/                    # Forward and reverse income tax calculations
-  return_sequences/       # Market return generators (constant, mean, GBM)
+  return_sequences/       # Market return generators (constant, mean, GBM, recorded)
+  failed_runs/            # Capture machinery for failed success_rate runs
   output/                 # Console printing and formatting
   account.rb              # Account model (balance, withdraw, deposit, grow)
   app_config.rb           # Typed wrapper around inputs.yml
+  inputs_digest.rb        # Stable hash of replay-relevant inputs
   withdrawal_amounts.rb   # Per-account withdrawal amount calculations
   withdrawal_rate_calculator.rb
   first_year_cash_flow.rb
@@ -28,6 +30,7 @@ config/
   tax_fixed.yml           # Fixed tax config used in tests (deterministic)
   rrif.yml                # CRA prescribed RRIF withdrawal factors by age
   rrif_fixed.yml          # Fixed RRIF config used in tests
+failed_runs/              # Captured failed sequences from success_rate mode (gitignored)
 spec/                     # RSpec tests
   fixtures/               # YAML files used as AppConfig inputs in specs
 ```
@@ -73,11 +76,11 @@ flowchart TD
 
 ### Entry Points — `lib/run/`
 
-**`AppRunner`** reads `inputs.yml`, resolves the run mode (`detailed` or `success_rate`), and delegates to the appropriate run class. The mode can be overridden via `ARGV[0]` (used by the `ruby main.rb success_rate` command).
+**`AppRunner`** reads `inputs.yml`, resolves the run mode (`detailed` or `success_rate`), and delegates to the appropriate run class. The mode can be overridden via `ARGV[0]` (used by the `ruby main.rb success_rate` command). Validation: `mode: success_rate` combined with `return_sequence_type: recorded` errors at startup, since a deterministic sequence run N times would produce N identical results.
 
 **`SimulationDetailed`** orchestrates a single run: creates a `Simulator`, runs it, feeds the results to `SimulationEvaluator` and `FirstYearCashFlow`, then prints everything via `ConsolePrinter`.
 
-**`SuccessRateSimulation`** runs `Simulator` N times (default 500), collects `{success, withdrawal_rate, final_balance}` from each, aggregates into `SuccessRateResults`, and prints via `SuccessRatePrinter`.
+**`SuccessRateSimulation`** runs `Simulator` N times (default 500), collects `{success, withdrawal_rate, final_balance}` from each, aggregates into `SuccessRateResults`, and prints via `SuccessRatePrinter`. It also drives the `FailedRuns::Writer`: prepares the `failed_runs/` directory before the loop, offers each failed run to a reservoir sampler, and flushes the kept runs (plus a manifest) at the end.
 
 ---
 
@@ -151,6 +154,22 @@ Both calculators load from `config/tax.yml` in production, or `config/tax_fixed.
 - `drift` = `log(1 + average) - 0.5 × sigma²` (Itô correction to prevent drift above intended average)
 - `sigma` = derived from `min`/`max` via three-sigma rule: `(max - min) / 6`
 - `shock` = drawn from a Student-t distribution (df=10) for fat tails
+
+**`RecordedSequence`** — loads a previously-saved `{age => return}` map from disk instead of generating one. Used by detailed mode to replay a failed run captured by `success_rate` mode. Exposes the saved summary and inputs digest so `SimulationDetailed` can announce the replay and warn on digest mismatch.
+
+---
+
+### Failed Runs Capture — `lib/failed_runs/`
+
+**`ReservoirSampler`** — generic K-of-N reservoir (Algorithm R). Streaming-with-unknown-N selection so every failure that ever occurred has equal probability `K / total_seen` of ending up in the saved set, regardless of when it streamed past.
+
+**`Serializer`** — read/write for the per-run YAML schema (`id`, `captured_at`, `inputs_digest`, `outcome`, `return_sequence`).
+
+**`Manifest`** — writes `failed_runs/index.md`: header, capture timestamp, source digest, and one bullet per saved run with its summary.
+
+**`Writer`** — orchestrator. `prepare!` wipes prior `run_*.yml` and `index.md` (preserves `.gitkeep`); `offer(simulation_output, evaluator_results)` builds a payload from a single run and feeds it to the reservoir; `flush!` writes each kept payload to `run_NNNN.yml` and writes the manifest. Capacity hardcoded to 50.
+
+**`InputsDigest`** (in `lib/inputs_digest.rb`) — SHA256 over the *replay-relevant* subset of inputs: those that affect outcome when the return sequence is fixed. Excludes `mode`, `total_runs`, `return_sequence_type`, `recorded_sequence_file`, and the GBM/mean parameters (`average`/`min`/`max`) since the sequence comes from disk.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,16 @@ annual_growth_rate:
 #   (mean reversion), but this model does not simulate that — every year is drawn
 #   independently. Think of it as: "if the future is somewhat worse than history, will
 #   my plan survive?" rather than: "how often has this worked historically?"
+#
+# `recorded`: replays a previously-captured return sequence from disk instead of
+#   generating one. Only valid in `detailed` mode. Used to inspect a single failed
+#   run from a prior `success_rate` invocation year-by-year. See README:
+#   "Inspecting Why Scenarios Fail".
 return_sequence_type: geometric_brownian_motion
+
+# When `return_sequence_type: recorded`, points to the saved YAML file to replay —
+# typically one of the files generated under `failed_runs/` by a `success_rate` run.
+# recorded_sequence_file: failed_runs/run_0001.yml
 
 # Optionally continue to make TFSA contributions during RRSP and Taxable drawdown phases.
 # If you don't want to make any TFSA contributions during drawdown, set this to 0.
@@ -194,6 +203,20 @@ taxes:
 ```
 
 ---
+
+## Replaying a Captured Failure
+
+When `return_sequence_type: recorded`, set `recorded_sequence_file` to the path of a saved YAML file under `failed_runs/`. Detailed mode loads that file and replays its `{age => return}` map year by year — same printer, same charts, same evaluation as a normal detailed run, but driven by deterministic captured data.
+
+Each saved run also stores a SHA256 digest of the inputs that produced it (the `inputs_digest` field). On replay, the simulator compares this stored digest to a digest of the *current* `inputs.yml`. If they differ, you'll see this note:
+
+> Note: inputs.yml has changed since this run was captured. The original failure may not reproduce exactly.
+
+This is informational only — the run is not blocked. The mismatch is itself useful: it lets you pair a captured "bad sequence" with modified inputs (e.g. lower spending, an added annuity) to test whether the plan would have survived under different assumptions.
+
+One field deserves special mention: `retirement_age`. Replay is **age-aligned**, not retirement-aligned — the year you simulate at age N uses whatever return the captured sequence had at age N. If you raise `retirement_age` above the original capture's value, you're replaying the *back half* of the original sequence (skipping the early years), not the same return pattern shifted in time. If you lower `retirement_age` below the captured range — or raise `max_age` above it — the requested ages fall outside the saved data, and the simulator exits at startup with an error pointing at the mismatch. To replay the same return pattern from a later starting balance, you'd need to re-capture under the new `retirement_age` rather than re-pointing at an old file.
+
+The digest covers fields that affect simulation outcome when the return sequence is fixed: balances, ages, spending, taxes, CPP/OAS/annuity, success factor, and the cash-cushion `downturn_threshold` and `savings` rate. It deliberately excludes `mode`, `total_runs`, `return_sequence_type`, `recorded_sequence_file`, and the GBM/mean parameters (`average`/`min`/`max`) — toggling between modes or pointing at a different recorded file does not invalidate the digest.
 
 ## First Year Cash Flow
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -221,6 +221,14 @@ This is the realistic option. Each year gets an independently drawn return — m
 
 **No mean reversion — by design:** Real markets tend to recover after crashes — cheap prices attract buyers and push returns back up. This model does not simulate that. Every year is drawn independently, with no memory of previous years. This means the model can generate extended bad stretches that real markets would typically recover from faster. The result is more conservative success rates than historical studies (like the original 4% rule research) produce for the same withdrawal rate. This is intentional: the goal is to stress-test your plan against futures that could be worse than history, not to reproduce historical outcomes.
 
+### `recorded`
+
+Loads a previously-saved sequence from a YAML file rather than generating one. Used in detailed mode to replay a failure that was captured during a prior `success_rate` run. See [Inspecting Why Scenarios Fail](../README.md#inspecting-why-scenarios-fail) for the workflow.
+
+### Inspecting failed runs
+
+`success_rate` mode persists a sample of failed return sequences to `failed_runs/`, with a one-line summary per run in `failed_runs/index.md`. Each saved file contains the `{age => return}` map plus a digest of the inputs that produced it, so the same scenario can be replayed year-by-year through detailed mode — answering "what *kind* of bad luck does my 5% failure rate look like?" rather than just "5% of runs fail." See the README for the full workflow.
+
 ---
 
 ## Cash Cushion

--- a/inputs.yml.template
+++ b/inputs.yml.template
@@ -61,8 +61,9 @@ annual_growth_rate:
   downturn_threshold: -0.1
   savings: 0.005
 
-# Choose the return sequence generator: mean, geometric_brownian_motion, constant
-# If using `success_rate` mode, then choose either `mean` or `geometric_brownian_motion`
+# Choose the return sequence generator: mean, geometric_brownian_motion, constant, recorded
+# If using `success_rate` mode, then choose either `mean` or `geometric_brownian_motion`.
+# `recorded` is only valid in `detailed` mode — see "Inspecting why scenarios fail" in the README.
 #
 # `constant`: every year returns exactly the average. Easy to understand and produces
 #   clean, predictable results, but completely unrealistic — markets don't do this.
@@ -85,6 +86,14 @@ annual_growth_rate:
 #   Think of it as: "if the future is somewhat worse than history, will my plan survive?"
 #   rather than: "how often has this worked historically?"
 return_sequence_type: geometric_brownian_motion
+
+# When `return_sequence_type: recorded`, this points to a saved YAML file
+# containing a previously-captured return sequence — typically one of the
+# files generated under `failed_runs/` by a `success_rate` run. Replays the
+# stored year-by-year returns through detailed mode, so you can inspect the
+# scenario that made the plan fail.
+#
+# recorded_sequence_file: failed_runs/run_0001.yml
 
 # Optionally continue to make TFSA contributions during RRSP and Taxable drawdown phases
 # If you don't want to make any TFSA contributions during drawdown, set this to 0.

--- a/lib/failed_runs/manifest.rb
+++ b/lib/failed_runs/manifest.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module FailedRuns
+  # Writes a human-readable index.md alongside saved failure YAML files,
+  # listing each saved run with a one-line summary.
+  class Manifest
+    FILENAME = "index.md"
+
+    def self.write(dir, entries, captured_at: Time.now.utc, inputs_digest: nil)
+      lines = ["# Failed runs from success_rate mode", ""]
+      lines << "Captured: #{captured_at.iso8601}"
+      lines << "Source inputs digest: #{inputs_digest}" if inputs_digest
+      lines << ""
+      sorted = entries.sort_by { |e| e[:filename] }
+      sorted.each do |entry|
+        lines << "- #{entry[:filename]} — #{entry[:summary]}"
+      end
+      lines << ""
+      File.write(File.join(dir, FILENAME), lines.join("\n"))
+    end
+  end
+end

--- a/lib/failed_runs/reservoir_sampler.rb
+++ b/lib/failed_runs/reservoir_sampler.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module FailedRuns
+  # Streaming K-of-N reservoir sampler (Algorithm R).
+  #
+  # Why reservoir? Failures stream in as the simulator runs N independent trials,
+  # and we don't know upfront how many failures will occur. Naively keeping
+  # "the first K" biases the saved set toward whatever the early iterations
+  # happened to produce. Reservoir sampling guarantees that every item in the
+  # stream has equal probability (K / total_seen) of ending up in the saved set,
+  # regardless of when it streamed past — without needing to know the total
+  # count upfront and without buffering everything.
+  #
+  # Algorithm:
+  #   - For the first K items: keep them all.
+  #   - For item i (i > K): draw a random integer j in [0, i). If j < K, the
+  #     new item replaces slot j. Otherwise discard.
+  class ReservoirSampler
+    def initialize(capacity, rng: Random.new)
+      @capacity = capacity
+      @rng = rng
+      @items = []
+      @seen_count = 0
+    end
+
+    def offer(item)
+      @seen_count += 1
+      if @items.size < @capacity
+        @items << item
+      else
+        j = @rng.rand(@seen_count)
+        @items[j] = item if j < @capacity
+      end
+    end
+
+    def to_a
+      @items.dup
+    end
+
+    attr_reader :seen_count, :capacity
+  end
+end

--- a/lib/failed_runs/serializer.rb
+++ b/lib/failed_runs/serializer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module FailedRuns
+  # Reads and writes the YAML schema for a single saved failed run.
+  #
+  # Schema:
+  #   id: run_NNNN
+  #   captured_at: <ISO8601 timestamp>
+  #   inputs_digest: <sha256 hex>
+  #   outcome:
+  #     success: false
+  #     summary: "ran out at age 84, final balance $0"
+  #     final_age: 84
+  #     final_balance: 0
+  #     withdrawal_rate: 0.04
+  #   return_sequence:
+  #     65: 0.0623
+  #     ...
+  class Serializer
+    PERMITTED_CLASSES = [Time, Date, Symbol].freeze
+
+    def self.write(path, payload)
+      File.write(path, payload.to_yaml)
+    end
+
+    def self.read(path)
+      YAML.load_file(path, permitted_classes: PERMITTED_CLASSES)
+    end
+  end
+end

--- a/lib/failed_runs/writer.rb
+++ b/lib/failed_runs/writer.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module FailedRuns
+  # Orchestrates the capture of failed runs in success_rate mode:
+  #   - prepare!: wipe prior run_*.yml + index.md from the directory
+  #   - offer:    build a payload from a single failed run, feed it through
+  #               the reservoir sampler (cap = CAPACITY)
+  #   - flush!:   write the kept payloads as run_NNNN.yml files, plus index.md
+  class Writer
+    CAPACITY = 50
+    DEFAULT_DIR = "failed_runs"
+
+    def initialize(app_config, output_dir: DEFAULT_DIR, capacity: CAPACITY,
+                   rng: Random.new, clock: -> { Time.now.utc })
+      @app_config = app_config
+      @output_dir = output_dir
+      @capacity = capacity
+      @clock = clock
+      @sampler = ReservoirSampler.new(capacity, rng: rng)
+      @max_age = app_config["max_age"]
+      @inputs_digest = InputsDigest.for(app_config)
+    end
+
+    def prepare!
+      FileUtils.mkdir_p(@output_dir)
+      FileUtils.rm_f(Dir.glob(File.join(@output_dir, "run_*.yml")))
+      FileUtils.rm_f(File.join(@output_dir, FailedRuns::Manifest::FILENAME))
+      puts "Clearing #{@output_dir}/ from previous success_rate run."
+    end
+
+    def offer(simulation_output, evaluator_results)
+      return if evaluator_results[:success]
+
+      payload = build_payload(simulation_output, evaluator_results)
+      @sampler.offer(payload)
+    end
+
+    def flush!
+      kept = @sampler.to_a
+      entries = write_payloads(kept)
+      FailedRuns::Manifest.write(@output_dir, entries,
+                                 captured_at: @clock.call,
+                                 inputs_digest: @inputs_digest)
+      puts "Saved #{kept.size} failed runs to #{@output_dir}/ " \
+           "(#{kept.size}/#{@sampler.seen_count} failures kept; " \
+           "see #{@output_dir}/#{FailedRuns::Manifest::FILENAME})."
+    end
+
+    private
+
+    def write_payloads(payloads)
+      payloads.each_with_index.map do |payload, idx|
+        filename = filename_for(idx)
+        payload["id"] = File.basename(filename, ".yml")
+        FailedRuns::Serializer.write(File.join(@output_dir, filename), payload)
+        { filename: filename, summary: payload.dig("outcome", "summary") }
+      end
+    end
+
+    def filename_for(index)
+      format("run_%04d.yml", index + 1)
+    end
+
+    def build_payload(simulation_output, evaluator_results)
+      yearly = simulation_output[:yearly_results]
+      last = yearly.last
+      {
+        "id" => nil,
+        "captured_at" => @clock.call,
+        "inputs_digest" => @inputs_digest,
+        "outcome" => {
+          "success" => false,
+          "summary" => build_summary(last),
+          "final_age" => last[:age],
+          "final_balance" => last[:total_balance],
+          "withdrawal_rate" => evaluator_results[:withdrawal_rate]
+        },
+        "return_sequence" => stringify_return_sequence(simulation_output[:return_sequence])
+      }
+    end
+
+    def build_summary(last_row)
+      balance = format_currency(last_row[:total_balance])
+      return "ran out at age #{last_row[:age]}, final balance #{balance}" if last_row[:age] < @max_age
+
+      threshold = @app_config["success_factor"] * @app_config["desired_spending"]
+      "reached max_age #{@max_age} with #{balance} (below threshold #{format_currency(threshold)})"
+    end
+
+    def format_currency(amount)
+      "$#{format('%.0f', amount)}"
+    end
+
+    def stringify_return_sequence(map)
+      map.each_with_object({}) { |(age, rate), h| h[age.to_i] = rate.to_f }
+    end
+  end
+end

--- a/lib/inputs_digest.rb
+++ b/lib/inputs_digest.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "digest"
+
+# Computes a stable SHA256 digest over the inputs that affect simulation
+# outcomes when the return sequence is fixed. Used to flag mismatches when
+# replaying a captured failure against edited inputs.
+#
+# Excludes fields that don't affect outcome on recorded replay: mode,
+# total_runs, return_sequence_type, recorded_sequence_file, and the GBM/mean
+# parameters (average/min/max) since the sequence comes from disk.
+class InputsDigest
+  RELEVANT_TOP_LEVEL_KEYS = %w[
+    retirement_age
+    max_age
+    province_code
+    success_factor
+    desired_spending
+    annual_tfsa_contribution
+    accounts
+    cpp
+    oas
+    annuity
+    taxes
+  ].freeze
+
+  RELEVANT_GROWTH_KEYS = %w[downturn_threshold savings].freeze
+
+  def self.for(app_config)
+    new(app_config).digest
+  end
+
+  def initialize(app_config)
+    @app_config = app_config
+  end
+
+  def digest
+    Digest::SHA256.hexdigest(canonical_yaml)
+  end
+
+  private
+
+  def canonical_yaml
+    relevant_subset.to_yaml
+  end
+
+  def relevant_subset
+    subset = {}
+    RELEVANT_TOP_LEVEL_KEYS.each do |key|
+      subset[key] = sort_deeply(@app_config[key]) if @app_config[key]
+    end
+    growth = @app_config.annual_growth_rate
+    if growth
+      growth_subset = RELEVANT_GROWTH_KEYS.each_with_object({}) do |k, h|
+        h[k] = growth[k] if growth.key?(k)
+      end
+      subset["annual_growth_rate"] = growth_subset unless growth_subset.empty?
+    end
+    sort_deeply(subset)
+  end
+
+  def sort_deeply(value)
+    case value
+    when Hash then value.keys.sort_by(&:to_s).each_with_object({}) { |k, h| h[k] = sort_deeply(value[k]) }
+    when Array then value.map { |v| sort_deeply(v) }
+    else value
+    end
+  end
+end

--- a/lib/return_sequences/base_sequence.rb
+++ b/lib/return_sequences/base_sequence.rb
@@ -17,6 +17,17 @@ module ReturnSequences
       @returns[age] || @avg
     end
 
+    # Exposes the materialized {age => return} map. Used by `success_rate`
+    # mode to persist failed sequences to disk (see `FailedRuns::Writer`),
+    # and by `Simulator#build_results` to surface the sequence alongside
+    # yearly results. Forces generation on first call (same lazy `||=`
+    # pattern as `get_return_for_age`), and returns a copy so callers can't
+    # mutate the sequence's internal state.
+    def returns_by_age
+      @returns ||= generate_returns
+      @returns.dup
+    end
+
     protected
 
     def generate_returns

--- a/lib/return_sequences/recorded_sequence.rb
+++ b/lib/return_sequences/recorded_sequence.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module ReturnSequences
+  # Loads a previously-saved {age => return} sequence from a YAML file rather
+  # than generating one. Used in `detailed` mode to replay a captured failure
+  # produced by `success_rate` mode.
+  class RecordedSequence < ReturnSequences::BaseSequence
+    REQUIRED_KEY = "return_sequence"
+
+    attr_reader :file_path
+
+    # `start_age` and `max_age` must be the same bounds the simulator will
+    # iterate over — i.e. `AppConfig#retirement_age` and `AppConfig#max_age`.
+    # In production this is enforced structurally: `SequenceSelector` builds
+    # both this object and the `Simulator` from the same `AppConfig`, so
+    # they share a single source of truth. `validate_range_coverage!`
+    # depends on that contract — it checks the file against these args
+    # rather than asking the simulator directly.
+    def initialize(start_age, max_age, file_path)
+      super(start_age, max_age, nil, nil, nil)
+      @file_path = file_path
+      @payload = load_payload
+      validate_range_coverage!
+    end
+
+    def summary
+      payload.dig("outcome", "summary")
+    end
+
+    def inputs_digest
+      payload["inputs_digest"]
+    end
+
+    protected
+
+    def generate_returns
+      raw = payload[REQUIRED_KEY]
+      raw.each_with_object({}) { |(age, ret), h| h[Integer(age)] = Float(ret) }
+    end
+
+    private
+
+    attr_reader :payload
+
+    def load_payload
+      raise "Recorded sequence file not found: #{@file_path}" unless File.exist?(@file_path)
+
+      data = YAML.load_file(@file_path, permitted_classes: [Time, Date, Symbol])
+      unless data.is_a?(Hash) && data.key?(REQUIRED_KEY) && data[REQUIRED_KEY].is_a?(Hash)
+        raise "Recorded sequence file #{@file_path} is malformed: missing or invalid '#{REQUIRED_KEY}' map"
+      end
+
+      data
+    end
+
+    # Ensures the recorded file has a return entry for every age the simulator
+    # will ask about. The simulator iterates `(start_age..max_age)` and looks
+    # up each age in the loaded map; without this check, an uncovered age
+    # would fall through to `BaseSequence#get_return_for_age`'s `@returns[age]
+    # || @avg` fallback. RecordedSequence has no average to fall back on (it
+    # passes `nil` for `avg` to `super`), so the simulator would receive a
+    # `nil` market return and crash several frames later in
+    # `Strategy::RrspToTaxableToTfsa#withdraw_from_cash_cushion?` with a
+    # confusing `NoMethodError: undefined method '<' for nil`. Failing here
+    # instead surfaces the real cause — a mismatch between the captured
+    # range and the requested range — at construction time, before any
+    # simulation runs.
+    #
+    # Coverage rule: the file's recorded ages must span at least
+    # `start_age..max_age`. The file may extend further on either side
+    # without issue (extra entries are just unused lookups), but it must
+    # not be missing either end of the requested range.
+    def validate_range_coverage!
+      ages = @payload[REQUIRED_KEY].keys.map { |k| Integer(k) }
+      file_min, file_max = ages.minmax
+      return if @start_age >= file_min && @max_age <= file_max
+
+      raise <<~MSG
+        Recorded sequence file does not cover the requested age range.
+          File:      #{@file_path}
+          Requested: ages #{@start_age}..#{@max_age}
+          Covered:   ages #{file_min}..#{file_max}
+        Fix: raise retirement_age to #{file_min} (or higher) and lower max_age to #{file_max} (or lower) in inputs.yml,
+        or point recorded_sequence_file at a capture covering #{@start_age}..#{@max_age}.
+      MSG
+    end
+  end
+end

--- a/lib/return_sequences/sequence_selector.rb
+++ b/lib/return_sequences/sequence_selector.rb
@@ -11,27 +11,32 @@ module ReturnSequences
     end
 
     def select
-      klass = determine_return_sequence_class
-      instantiate_return_sequence(klass)
+      sequence_type = app_config["return_sequence_type"] || DEFAULT_RETURN_SEQUENCE_TYPE
+      case sequence_type
+      when "mean" then instantiate_generative(ReturnSequences::MeanReturnSequence)
+      when "geometric_brownian_motion" then instantiate_generative(ReturnSequences::GeometricBrownianMotionSequence)
+      when "constant" then instantiate_generative(ReturnSequences::ConstantReturnSequence)
+      when "recorded" then instantiate_recorded
+      else raise "Unknown return_sequence_type: #{sequence_type}"
+      end
     end
 
     private
 
     attr_reader :app_config, :retirement_age, :max_age
 
-    def determine_return_sequence_class
-      sequence_type = app_config["return_sequence_type"] || DEFAULT_RETURN_SEQUENCE_TYPE
-      case sequence_type
-      when "mean" then ReturnSequences::MeanReturnSequence
-      when "geometric_brownian_motion" then ReturnSequences::GeometricBrownianMotionSequence
-      when "constant" then ReturnSequences::ConstantReturnSequence
-      else raise "Unknown return_sequence_type: #{app_config['return_sequence_type']}"
-      end
-    end
-
-    def instantiate_return_sequence(klass)
+    def instantiate_generative(klass)
       klass.new(retirement_age, max_age, app_config.annual_growth_rate["average"],
                 app_config.annual_growth_rate["min"], app_config.annual_growth_rate["max"])
+    end
+
+    def instantiate_recorded
+      file_path = app_config["recorded_sequence_file"]
+      if file_path.nil? || file_path.empty?
+        raise "return_sequence_type: recorded requires recorded_sequence_file in inputs"
+      end
+
+      ReturnSequences::RecordedSequence.new(retirement_age, max_age, file_path)
     end
   end
 end

--- a/lib/run/app_config_validator.rb
+++ b/lib/run/app_config_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Run
+  class AppConfigValidator
+    def self.validate!(app_config, mode)
+      new(app_config, mode).validate!
+    end
+
+    def initialize(app_config, mode)
+      @app_config = app_config
+      @mode = mode
+    end
+
+    def validate!
+      validate_recorded_only_in_detailed!
+    end
+
+    private
+
+    attr_reader :app_config, :mode
+
+    def validate_recorded_only_in_detailed!
+      return unless mode == "success_rate" && app_config["return_sequence_type"] == "recorded"
+
+      raise "`return_sequence_type: recorded` is only valid with `mode: detailed`. " \
+            "A recorded sequence is deterministic — running it 1000 times would " \
+            "produce 1000 identical results."
+    end
+  end
+end

--- a/lib/run/app_runner.rb
+++ b/lib/run/app_runner.rb
@@ -3,12 +3,15 @@
 module Run
   class AppRunner
     def initialize(config_file, mode_override = nil)
+      @config_file = config_file
       @app_config = AppConfig.new(config_file)
       @mode = mode_override || @app_config["mode"] || "detailed"
-      puts "AppRunner initialized with config: #{config_file}, resolved mode: #{@mode}"
     end
 
     def run
+      puts "AppRunner initialized with config: #{config_file}, resolved mode: #{mode}"
+      AppConfigValidator.validate!(app_config, mode)
+
       case mode
       when "detailed" then SimulationDetailed.new(app_config).run
       when "success_rate" then SuccessRateSimulation.new(app_config).run
@@ -18,6 +21,6 @@ module Run
 
     private
 
-    attr_reader :app_config, :mode
+    attr_reader :config_file, :app_config, :mode
   end
 end

--- a/lib/run/simulation_detailed.rb
+++ b/lib/run/simulation_detailed.rb
@@ -7,6 +7,7 @@ module Run
     end
 
     def run
+      announce_replay_if_recorded
       summary = app_config.summary
       first_year_cash_flow_results = FirstYearCashFlow.new(app_config).calculate
       simulation_output = Simulation::Simulator.new(app_config).run
@@ -17,5 +18,25 @@ module Run
     private
 
     attr_reader :app_config
+
+    def announce_replay_if_recorded
+      return unless app_config["return_sequence_type"] == "recorded"
+
+      file_path = app_config["recorded_sequence_file"]
+      sequence = ReturnSequences::RecordedSequence.new(
+        app_config["retirement_age"], app_config["max_age"], file_path
+      )
+      label = sequence.summary || "from #{File.basename(file_path)}"
+      puts "Replaying #{File.basename(file_path, '.yml')}: #{label}"
+      warn_on_digest_mismatch(sequence)
+    end
+
+    def warn_on_digest_mismatch(sequence)
+      stored = sequence.inputs_digest
+      return if stored.nil? || stored == InputsDigest.for(app_config)
+
+      puts "Note: inputs.yml has changed since this run was captured. " \
+           "The original failure may not reproduce exactly."
+    end
   end
 end

--- a/lib/run/simulation_success_rate.rb
+++ b/lib/run/simulation_success_rate.rb
@@ -2,13 +2,15 @@
 
 module Run
   class SuccessRateSimulation
-    def initialize(app_config)
+    def initialize(app_config, failed_runs_writer: nil)
       @app_config = app_config
       @total_runs = app_config["total_runs"] || 500
       @simulation_results = []
+      @failed_runs_writer = failed_runs_writer || FailedRuns::Writer.new(app_config)
     end
 
     def run
+      @failed_runs_writer.prepare!
       progress_bar = create_progress_bar
 
       total_runs.times do
@@ -19,6 +21,7 @@ module Run
         progress_bar.advance
       end
 
+      @failed_runs_writer.flush!
       results = SuccessRateResults.new(simulation_results)
       Output::SuccessRatePrinter.new(results).print_summary
     end
@@ -38,14 +41,15 @@ module Run
     end
 
     def simulate_once
-      simulation_results = Simulation::Simulator.new(app_config).run
-      evaluator_results = Simulation::SimulationEvaluator.new(simulation_results[:yearly_results], app_config).evaluate
-      annuity_skipped = simulation_results[:yearly_results].any? { |r| r[:annuity_purchase_skipped] }
+      simulation_output = Simulation::Simulator.new(app_config).run
+      evaluator_results = Simulation::SimulationEvaluator.new(simulation_output[:yearly_results], app_config).evaluate
+      annuity_skipped = simulation_output[:yearly_results].any? { |r| r[:annuity_purchase_skipped] }
+      @failed_runs_writer.offer(simulation_output, evaluator_results)
 
       [
         evaluator_results[:success] ? true : false,
         evaluator_results[:withdrawal_rate],
-        simulation_results[:yearly_results].last[:total_balance],
+        simulation_output[:yearly_results].last[:total_balance],
         annuity_skipped
       ]
     end

--- a/lib/simulation/simulator.rb
+++ b/lib/simulation/simulator.rb
@@ -74,7 +74,7 @@ module Simulation
     end
 
     def build_results
-      { yearly_results: results }
+      { yearly_results: results, return_sequence: return_sequence.returns_by_age }
     end
 
     def build_note(account_transactions)

--- a/spec/fixtures/recorded_runs/sample.yml
+++ b/spec/fixtures/recorded_runs/sample.yml
@@ -1,0 +1,15 @@
+id: run_sample
+captured_at: 2026-05-02T14:30:00Z
+inputs_digest: deadbeef
+outcome:
+  success: false
+  summary: "ran out at age 67, final balance $0"
+  final_age: 67
+  final_balance: 0
+  withdrawal_rate: 0.04
+return_sequence:
+  65: 0.05
+  66: -0.30
+  67: -0.20
+  68: 0.02
+  69: 0.04

--- a/spec/fixtures/sequence_recorded.yml
+++ b/spec/fixtures/sequence_recorded.yml
@@ -1,0 +1,6 @@
+return_sequence_type: recorded
+recorded_sequence_file: spec/fixtures/recorded_runs/sample.yml
+annual_growth_rate:
+  average: 0.05
+  min: -0.4
+  max: 0.45

--- a/spec/lib/failed_runs/manifest_spec.rb
+++ b/spec/lib/failed_runs/manifest_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "../../spec_helper"
+
+RSpec.describe FailedRuns::Manifest do
+  let(:entries) do
+    [
+      { filename: "run_0002.yml", summary: "reached 95 with $12,400 (below 40k threshold)" },
+      { filename: "run_0001.yml", summary: "ran out at age 79, final balance $0" }
+    ]
+  end
+
+  def write_in_tmp(&)
+    Dir.mktmpdir do |dir|
+      described_class.write(dir, entries,
+                            captured_at: Time.utc(2026, 5, 2, 14, 30, 0),
+                            inputs_digest: "abc123")
+      yield File.read(File.join(dir, "index.md"))
+    end
+  end
+
+  it "includes the header and metadata block" do
+    write_in_tmp do |contents|
+      expect(contents).to include("# Failed runs from success_rate mode",
+                                  "Captured: 2026-05-02T14:30:00Z",
+                                  "Source inputs digest: abc123")
+    end
+  end
+
+  it "includes one bullet per entry with summary text" do
+    write_in_tmp do |contents|
+      expect(contents).to include("- run_0001.yml — ran out at age 79, final balance $0",
+                                  "- run_0002.yml — reached 95 with $12,400 (below 40k threshold)")
+    end
+  end
+
+  it "sorts entries by filename ascending" do
+    write_in_tmp do |contents|
+      expect(contents.index("run_0001.yml")).to be < contents.index("run_0002.yml")
+    end
+  end
+end

--- a/spec/lib/failed_runs/reservoir_sampler_spec.rb
+++ b/spec/lib/failed_runs/reservoir_sampler_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe FailedRuns::ReservoirSampler do
+  describe "#offer / #to_a" do
+    it "keeps all items when fewer than capacity offered" do
+      sampler = described_class.new(3)
+      %i[a b c].each { |i| sampler.offer(i) }
+      expect(sampler.to_a).to eq(%i[a b c])
+    end
+
+    it "stays at capacity when more than capacity offered" do
+      sampler = described_class.new(3)
+      1000.times { |i| sampler.offer(i) }
+      expect(sampler.to_a.size).to eq(3)
+      expect(sampler.seen_count).to eq(1000)
+    end
+  end
+
+  describe "uniform inclusion probability" do
+    it "each offered item has approximately K/N probability of inclusion" do
+      capacity = 3
+      stream_size = 100
+      target_item = 50
+      trials = 10_000
+      rng = Random.new(42)
+
+      hits = 0
+      trials.times do
+        sampler = described_class.new(capacity, rng: rng)
+        stream_size.times { |i| sampler.offer(i) }
+        hits += 1 if sampler.to_a.include?(target_item)
+      end
+
+      empirical = hits.to_f / trials
+      expected = capacity.to_f / stream_size
+      expect(empirical).to be_within(0.015).of(expected)
+    end
+  end
+end

--- a/spec/lib/failed_runs/serializer_spec.rb
+++ b/spec/lib/failed_runs/serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "tempfile"
+require_relative "../../spec_helper"
+
+RSpec.describe FailedRuns::Serializer do
+  let(:payload) do
+    {
+      "id" => "run_0001",
+      "captured_at" => Time.utc(2026, 5, 2, 14, 30, 0),
+      "inputs_digest" => "abc123",
+      "outcome" => {
+        "success" => false,
+        "summary" => "ran out at age 84, final balance $0",
+        "final_age" => 84,
+        "final_balance" => 0,
+        "withdrawal_rate" => 0.04
+      },
+      "return_sequence" => { 65 => 0.0623, 66 => -0.2845 }
+    }
+  end
+
+  it "round-trips through write and read" do
+    Tempfile.create(["run", ".yml"]) do |f|
+      f.close
+      described_class.write(f.path, payload)
+      expect(described_class.read(f.path)).to eq(payload)
+    end
+  end
+
+  it "writes valid YAML at the documented schema's top-level keys" do
+    Tempfile.create(["run", ".yml"]) do |f|
+      f.close
+      described_class.write(f.path, payload)
+      loaded = described_class.read(f.path)
+      expect(loaded.keys).to include("id", "captured_at", "inputs_digest", "outcome", "return_sequence")
+      expect(loaded["outcome"].keys).to include("success", "summary", "final_age", "final_balance", "withdrawal_rate")
+    end
+  end
+end

--- a/spec/lib/failed_runs/writer_spec.rb
+++ b/spec/lib/failed_runs/writer_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "../../spec_helper"
+
+RSpec.describe FailedRuns::Writer do
+  let(:app_config) do
+    AppConfig.new(
+      "retirement_age" => 65,
+      "max_age" => 95,
+      "province_code" => "ONT",
+      "annual_tfsa_contribution" => 0,
+      "desired_spending" => 40_000,
+      "success_factor" => 1,
+      "annual_growth_rate" => {
+        "average" => 0.05, "min" => -0.4, "max" => 0.45,
+        "downturn_threshold" => -0.1, "savings" => 0.005
+      },
+      "accounts" => { "rrsp" => 600_000, "taxable" => 200_000, "tfsa" => 200_000, "cash_cushion" => 0 },
+      "cpp" => { "start_age" => 65, "monthly_amount" => 0 },
+      "taxes" => { "rrsp_withholding_rate" => 0.3 }
+    )
+  end
+
+  def fake_failure_output(final_age: 84, final_balance: 0)
+    {
+      yearly_results: [
+        { age: 65, total_balance: 100_000, rate_of_return: 0.05 },
+        { age: final_age, total_balance: final_balance, rate_of_return: -0.05 }
+      ],
+      return_sequence: { 65 => 0.05, final_age => -0.05 }
+    }
+  end
+
+  def fake_eval(success:, withdrawal_rate: 0.04)
+    { success: success, withdrawal_rate: withdrawal_rate }
+  end
+
+  describe "#prepare!" do
+    it "removes existing run_*.yml and index.md but leaves .gitkeep" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, ".gitkeep"), "")
+        File.write(File.join(dir, "run_9999.yml"), "old")
+        File.write(File.join(dir, "index.md"), "old")
+        writer = described_class.new(app_config, output_dir: dir)
+        writer.prepare!
+        expect(File.exist?(File.join(dir, ".gitkeep"))).to be true
+        expect(File.exist?(File.join(dir, "run_9999.yml"))).to be false
+        expect(File.exist?(File.join(dir, "index.md"))).to be false
+      end
+    end
+  end
+
+  describe "#offer + #flush!" do
+    it "writes one file per offered failure when N <= capacity" do
+      Dir.mktmpdir do |dir|
+        writer = described_class.new(app_config, output_dir: dir, capacity: 50)
+        10.times { writer.offer(fake_failure_output, fake_eval(success: false)) }
+        writer.flush!
+        files = Dir.glob(File.join(dir, "run_*.yml"))
+        expect(files.size).to eq(10)
+        expect(files.min).to end_with("run_0001.yml")
+        expect(files.max).to end_with("run_0010.yml")
+        expect(File.exist?(File.join(dir, "index.md"))).to be true
+      end
+    end
+
+    it "caps at exactly capacity when N > capacity" do
+      Dir.mktmpdir do |dir|
+        writer = described_class.new(app_config, output_dir: dir, capacity: 50)
+        200.times { writer.offer(fake_failure_output, fake_eval(success: false)) }
+        writer.flush!
+        files = Dir.glob(File.join(dir, "run_*.yml"))
+        expect(files.size).to eq(50)
+      end
+    end
+
+    it "rejects successful runs offered" do
+      Dir.mktmpdir do |dir|
+        writer = described_class.new(app_config, output_dir: dir)
+        5.times { writer.offer(fake_failure_output, fake_eval(success: true)) }
+        writer.flush!
+        files = Dir.glob(File.join(dir, "run_*.yml"))
+        expect(files).to be_empty
+      end
+    end
+
+    it "writes a manifest whose summaries match each saved run" do
+      Dir.mktmpdir do |dir|
+        writer = described_class.new(app_config, output_dir: dir)
+        writer.offer(fake_failure_output(final_age: 79, final_balance: 0), fake_eval(success: false))
+        writer.offer(fake_failure_output(final_age: 95, final_balance: 12_400), fake_eval(success: false))
+        writer.flush!
+        manifest = File.read(File.join(dir, "index.md"))
+        Dir.glob(File.join(dir, "run_*.yml")).each do |path|
+          payload = FailedRuns::Serializer.read(path)
+          expect(manifest).to include(File.basename(path))
+          expect(manifest).to include(payload.dig("outcome", "summary"))
+        end
+      end
+    end
+
+    it "writes each payload with the inputs digest" do
+      Dir.mktmpdir do |dir|
+        writer = described_class.new(app_config, output_dir: dir)
+        writer.offer(fake_failure_output, fake_eval(success: false))
+        writer.flush!
+        path = Dir.glob(File.join(dir, "run_*.yml")).first
+        payload = FailedRuns::Serializer.read(path)
+        expect(payload["inputs_digest"]).to eq(InputsDigest.for(app_config))
+      end
+    end
+
+    it "produces a 'ran out' summary when final_age < max_age" do
+      Dir.mktmpdir do |dir|
+        writer = described_class.new(app_config, output_dir: dir)
+        writer.offer(fake_failure_output(final_age: 79, final_balance: 0), fake_eval(success: false))
+        writer.flush!
+        path = Dir.glob(File.join(dir, "run_*.yml")).first
+        payload = FailedRuns::Serializer.read(path)
+        expect(payload.dig("outcome", "summary")).to match(/ran out at age 79/)
+      end
+    end
+
+    it "produces a 'reached max_age' summary when final_age == max_age but below threshold" do
+      Dir.mktmpdir do |dir|
+        writer = described_class.new(app_config, output_dir: dir)
+        writer.offer(fake_failure_output(final_age: 95, final_balance: 12_000), fake_eval(success: false))
+        writer.flush!
+        path = Dir.glob(File.join(dir, "run_*.yml")).first
+        payload = FailedRuns::Serializer.read(path)
+        expect(payload.dig("outcome", "summary")).to match(/reached max_age 95/)
+      end
+    end
+  end
+end

--- a/spec/lib/inputs_digest_spec.rb
+++ b/spec/lib/inputs_digest_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe InputsDigest do
+  let(:base_inputs) do
+    {
+      "retirement_age" => 65,
+      "max_age" => 95,
+      "province_code" => "ONT",
+      "annual_tfsa_contribution" => 0,
+      "desired_spending" => 40_000,
+      "success_factor" => 1,
+      "annual_growth_rate" => {
+        "average" => 0.05, "min" => -0.4, "max" => 0.45,
+        "downturn_threshold" => -0.1, "savings" => 0.005
+      },
+      "accounts" => { "rrsp" => 600_000, "taxable" => 200_000, "tfsa" => 200_000, "cash_cushion" => 40_000 },
+      "cpp" => { "start_age" => 65, "monthly_amount" => 0 },
+      "taxes" => { "rrsp_withholding_rate" => 0.3 }
+    }
+  end
+
+  it "produces the same digest for identical inputs" do
+    a = described_class.for(AppConfig.new(base_inputs.dup))
+    b = described_class.for(AppConfig.new(base_inputs.dup))
+    expect(a).to eq(b)
+  end
+
+  it "produces a different digest when desired_spending changes" do
+    a = described_class.for(AppConfig.new(base_inputs.dup))
+    changed = base_inputs.merge("desired_spending" => 35_000)
+    b = described_class.for(AppConfig.new(changed))
+    expect(a).not_to eq(b)
+  end
+
+  it "ignores mode (excluded from digest)" do
+    a = described_class.for(AppConfig.new(base_inputs.merge("mode" => "detailed")))
+    b = described_class.for(AppConfig.new(base_inputs.merge("mode" => "success_rate")))
+    expect(a).to eq(b)
+  end
+
+  it "ignores total_runs (excluded from digest)" do
+    a = described_class.for(AppConfig.new(base_inputs.merge("total_runs" => 100)))
+    b = described_class.for(AppConfig.new(base_inputs.merge("total_runs" => 1000)))
+    expect(a).to eq(b)
+  end
+
+  it "ignores return_sequence_type and recorded_sequence_file" do
+    a_inputs = base_inputs.merge("return_sequence_type" => "geometric_brownian_motion")
+    b_inputs = base_inputs.merge(
+      "return_sequence_type" => "recorded",
+      "recorded_sequence_file" => "failed_runs/run_0001.yml"
+    )
+    a = described_class.for(AppConfig.new(a_inputs))
+    b = described_class.for(AppConfig.new(b_inputs))
+    expect(a).to eq(b)
+  end
+
+  it "ignores annual_growth_rate.average/min/max changes" do
+    a = described_class.for(AppConfig.new(base_inputs))
+    other = base_inputs.deep_dup if base_inputs.respond_to?(:deep_dup)
+    other ||= Marshal.load(Marshal.dump(base_inputs))
+    other["annual_growth_rate"]["average"] = 0.10
+    other["annual_growth_rate"]["min"] = -0.5
+    other["annual_growth_rate"]["max"] = 0.5
+    b = described_class.for(AppConfig.new(other))
+    expect(a).to eq(b)
+  end
+
+  it "is sensitive to annual_growth_rate.downturn_threshold" do
+    a = described_class.for(AppConfig.new(base_inputs))
+    other = Marshal.load(Marshal.dump(base_inputs))
+    other["annual_growth_rate"]["downturn_threshold"] = -0.2
+    b = described_class.for(AppConfig.new(other))
+    expect(a).not_to eq(b)
+  end
+
+  it "is insensitive to key ordering in nested hashes" do
+    reordered = base_inputs.to_a.reverse.to_h
+    reordered["accounts"] = reordered["accounts"].to_a.reverse.to_h
+    a = described_class.for(AppConfig.new(base_inputs))
+    b = described_class.for(AppConfig.new(reordered))
+    expect(a).to eq(b)
+  end
+end

--- a/spec/lib/return_sequences/base_sequence_spec.rb
+++ b/spec/lib/return_sequences/base_sequence_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe ReturnSequences::BaseSequence do
+  describe "#returns_by_age" do
+    let(:start_age) { 60 }
+    let(:max_age) { 64 }
+    let(:avg) { 0.05 }
+    let(:min) { -0.2 }
+    let(:max) { 0.2 }
+
+    context "with a deterministic ConstantReturnSequence" do
+      subject(:sequence) { ReturnSequences::ConstantReturnSequence.new(start_age, max_age, avg, min, max) }
+
+      it "returns a hash with one entry per age in [start_age..max_age]" do
+        expect(sequence.returns_by_age.keys).to eq((start_age..max_age).to_a)
+      end
+
+      it "values match get_return_for_age for each age" do
+        (start_age..max_age).each do |age|
+          expect(sequence.returns_by_age[age]).to eq(sequence.get_return_for_age(age))
+        end
+      end
+
+      it "triggers generation lazily on a fresh instance" do
+        fresh = ReturnSequences::ConstantReturnSequence.new(start_age, max_age, avg, min, max)
+        expect(fresh.returns_by_age).not_to be_empty
+      end
+
+      it "returns a copy so callers cannot mutate the internal map" do
+        copy = sequence.returns_by_age
+        copy[start_age] = 999.0
+        expect(sequence.returns_by_age[start_age]).to eq(avg)
+      end
+    end
+
+    context "with a MeanReturnSequence (seeded for determinism)" do
+      subject(:sequence) { ReturnSequences::MeanReturnSequence.new(start_age, max_age, avg, min, max) }
+
+      before { srand(1234) }
+
+      it "values match get_return_for_age for each age" do
+        hash = sequence.returns_by_age
+        (start_age..max_age).each do |age|
+          expect(hash[age]).to eq(sequence.get_return_for_age(age))
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/return_sequences/recorded_sequence_spec.rb
+++ b/spec/lib/return_sequences/recorded_sequence_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "tempfile"
+require_relative "../../spec_helper"
+
+RSpec.describe ReturnSequences::RecordedSequence do
+  subject(:sequence) { described_class.new(65, 69, sample_path) }
+
+  let(:base_fixture_path) { File.expand_path("../../fixtures", __dir__) }
+  let(:sample_path) { File.join(base_fixture_path, "recorded_runs", "sample.yml") }
+
+  describe "#returns_by_age" do
+    it "returns the stored map keyed by integer ages with float values" do
+      expect(sequence.returns_by_age).to eq(
+        65 => 0.05,
+        66 => -0.30,
+        67 => -0.20,
+        68 => 0.02,
+        69 => 0.04
+      )
+    end
+  end
+
+  describe "#get_return_for_age" do
+    it "returns the stored return for each age" do
+      expect(sequence.get_return_for_age(65)).to eq(0.05)
+      expect(sequence.get_return_for_age(66)).to eq(-0.30)
+    end
+  end
+
+  describe "#file_path" do
+    it "exposes the source file path" do
+      expect(sequence.file_path).to eq(sample_path)
+    end
+  end
+
+  describe "#summary" do
+    it "exposes the saved outcome summary" do
+      expect(sequence.summary).to eq("ran out at age 67, final balance $0")
+    end
+  end
+
+  describe "#inputs_digest" do
+    it "exposes the saved inputs digest" do
+      expect(sequence.inputs_digest).to eq("deadbeef")
+    end
+  end
+
+  describe "range coverage validation" do
+    # The fixture covers ages 65..69. A request for a wider range cannot be
+    # served, since the missing ages would silently fall through to the
+    # superclass's @avg (nil for RecordedSequence) and crash deep in the
+    # withdrawal strategy with a confusing NilClass comparison error.
+    it "raises a clear error when start_age is below the file's min recorded age" do
+      expect do
+        described_class.new(60, 69, sample_path)
+      end.to raise_error(/does not cover/i)
+    end
+
+    it "raises a clear error when max_age is above the file's max recorded age" do
+      expect do
+        described_class.new(65, 75, sample_path)
+      end.to raise_error(/does not cover/i)
+    end
+  end
+
+  describe "missing or malformed file" do
+    it "raises when file is missing" do
+      expect do
+        described_class.new(65, 69, "/nonexistent/path.yml")
+      end.to raise_error(/not found/)
+    end
+
+    it "raises when file is missing the return_sequence key" do
+      Tempfile.create(["malformed", ".yml"]) do |f|
+        f.write({ "id" => "x" }.to_yaml)
+        f.close
+        expect do
+          described_class.new(65, 69, f.path)
+        end.to raise_error(/malformed/)
+      end
+    end
+  end
+end

--- a/spec/lib/return_sequences/sequence_selector_spec.rb
+++ b/spec/lib/return_sequences/sequence_selector_spec.rb
@@ -42,5 +42,29 @@ RSpec.describe ReturnSequences::SequenceSelector do
         expect(sequence).to be_an_instance_of(ReturnSequences::ConstantReturnSequence)
       end
     end
+
+    context "when selecting a 'recorded' return sequence" do
+      let(:app_config) { AppConfig.new(File.join(base_fixture_path, "sequence_recorded.yml")) }
+      let!(:sequence) { described_class.new(app_config, 65, 69).select }
+
+      it "returns an instance of RecordedSequence" do
+        expect(sequence).to be_an_instance_of(ReturnSequences::RecordedSequence)
+      end
+    end
+
+    context "when 'recorded' is selected but recorded_sequence_file is missing" do
+      let(:app_config) do
+        AppConfig.new(
+          "return_sequence_type" => "recorded",
+          "annual_growth_rate" => { "average" => 0.05, "min" => -0.4, "max" => 0.45 }
+        )
+      end
+
+      it "raises a clear error" do
+        expect do
+          described_class.new(app_config, 65, 100).select
+        end.to raise_error(/recorded_sequence_file/)
+      end
+    end
   end
 end

--- a/spec/lib/run/app_config_validator_spec.rb
+++ b/spec/lib/run/app_config_validator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe Run::AppConfigValidator do
+  def app_config(overrides = {})
+    AppConfig.new(overrides)
+  end
+
+  describe ".validate!" do
+    it "raises when mode: success_rate is combined with return_sequence_type: recorded" do
+      config = app_config("return_sequence_type" => "recorded")
+      expect do
+        described_class.validate!(config, "success_rate")
+      end.to raise_error(/recorded.*only valid with.*detailed/m)
+    end
+
+    it "does not raise when mode: detailed is combined with return_sequence_type: recorded" do
+      config = app_config("return_sequence_type" => "recorded")
+      expect { described_class.validate!(config, "detailed") }.not_to raise_error
+    end
+
+    it "does not raise on standard generative sequence types in success_rate mode" do
+      config = app_config("return_sequence_type" => "geometric_brownian_motion")
+      expect { described_class.validate!(config, "success_rate") }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/run/simulation_detailed_spec.rb
+++ b/spec/lib/run/simulation_detailed_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "tempfile"
+require "tmpdir"
+require_relative "../../spec_helper"
+
+RSpec.describe Run::SimulationDetailed do
+  let(:base_fixture_path) { File.expand_path("../../fixtures", __dir__) }
+
+  let(:base_inputs) do
+    YAML.load_file(File.join(base_fixture_path, "example_input_low_growth.yml")).merge(
+      "mode" => "detailed",
+      "max_age" => 69,
+      "retirement_age" => 65,
+      "success_factor" => 1,
+      "annual_growth_rate" => {
+        "average" => 0.05, "min" => -0.4, "max" => 0.45,
+        "downturn_threshold" => -0.1, "savings" => 0.005
+      }
+    )
+  end
+
+  def write_recorded_run(dir, inputs_digest:, summary: "ran out at age 67, final balance $0")
+    payload = {
+      "id" => "run_test",
+      "captured_at" => Time.utc(2026, 5, 1).iso8601,
+      "inputs_digest" => inputs_digest,
+      "outcome" => {
+        "success" => false, "summary" => summary,
+        "final_age" => 67, "final_balance" => 0, "withdrawal_rate" => 0.04
+      },
+      "return_sequence" => (65..69).each_with_object({}) { |age, h| h[age] = 0.05 }
+    }
+    path = File.join(dir, "run_test.yml")
+    File.write(path, payload.to_yaml)
+    path
+  end
+
+  it "announces the replayed run with its stored summary on a recorded sequence" do
+    Dir.mktmpdir do |dir|
+      app_config = AppConfig.new(base_inputs)
+      digest = InputsDigest.for(app_config)
+      path = write_recorded_run(dir, inputs_digest: digest)
+      replay_config = AppConfig.new(base_inputs.merge(
+                                      "return_sequence_type" => "recorded",
+                                      "recorded_sequence_file" => path
+                                    ))
+      expect do
+        described_class.new(replay_config).run
+      end.to output(/Replaying run_test: ran out at age 67, final balance \$0/).to_stdout
+    end
+  end
+
+  it "warns when stored digest differs from current inputs" do
+    Dir.mktmpdir do |dir|
+      path = write_recorded_run(dir, inputs_digest: "stale_digest_xyz")
+      replay_config = AppConfig.new(base_inputs.merge(
+                                      "return_sequence_type" => "recorded",
+                                      "recorded_sequence_file" => path
+                                    ))
+      expect do
+        described_class.new(replay_config).run
+      end.to output(/inputs.yml has changed since this run was captured/).to_stdout
+    end
+  end
+
+  it "does not warn when stored digest matches current inputs" do
+    Dir.mktmpdir do |dir|
+      app_config = AppConfig.new(base_inputs)
+      digest = InputsDigest.for(app_config)
+      path = write_recorded_run(dir, inputs_digest: digest)
+      replay_config = AppConfig.new(base_inputs.merge(
+                                      "return_sequence_type" => "recorded",
+                                      "recorded_sequence_file" => path
+                                    ))
+      expect do
+        described_class.new(replay_config).run
+      end.not_to output(/inputs.yml has changed since this run was captured/).to_stdout
+    end
+  end
+end

--- a/spec/lib/run/success_rate_simulation_spec.rb
+++ b/spec/lib/run/success_rate_simulation_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "../../spec_helper"
+
+RSpec.describe Run::SuccessRateSimulation do
+  let(:base_fixture_path) { File.expand_path("../../fixtures", __dir__) }
+
+  let(:inputs) do
+    YAML.load_file(File.join(base_fixture_path, "example_input_low_growth.yml")).merge(
+      "mode" => "success_rate",
+      "total_runs" => 10,
+      "return_sequence_type" => "geometric_brownian_motion",
+      # Force the average way down so most runs fail.
+      "annual_growth_rate" => {
+        "average" => -0.05, "min" => -0.4, "max" => 0.1,
+        "downturn_threshold" => -0.5, "savings" => 0.005
+      },
+      "success_factor" => 1
+    )
+  end
+
+  let(:app_config) { AppConfig.new(inputs) }
+
+  def run_in_tmp(&)
+    Dir.mktmpdir do |dir|
+      writer = FailedRuns::Writer.new(app_config, output_dir: dir)
+      yield dir, writer
+    end
+  end
+
+  def silently
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+
+  it "wipes prior run_*.yml files in prepare!" do
+    run_in_tmp do |dir, writer|
+      File.write(File.join(dir, "run_9999.yml"), "stale")
+      silently { described_class.new(app_config, failed_runs_writer: writer).run }
+      expect(File.exist?(File.join(dir, "run_9999.yml"))).to be false
+    end
+  end
+
+  it "writes captured failure files and a manifest listing them" do
+    run_in_tmp do |dir, writer|
+      silently { described_class.new(app_config, failed_runs_writer: writer).run }
+      files = Dir.glob(File.join(dir, "run_*.yml"))
+      manifest = File.read(File.join(dir, "index.md"))
+      expect(files).not_to be_empty
+      expect(files.size).to be <= 50
+      files.each { |path| expect(manifest).to include(File.basename(path)) }
+    end
+  end
+
+  it "stores the inputs digest in each saved run" do
+    run_in_tmp do |dir, writer|
+      silently { described_class.new(app_config, failed_runs_writer: writer).run }
+      expected = InputsDigest.for(app_config)
+      Dir.glob(File.join(dir, "run_*.yml")).each do |path|
+        payload = FailedRuns::Serializer.read(path)
+        expect(payload["inputs_digest"]).to eq(expected)
+      end
+    end
+  end
+
+  it "saved runs are replayable: detailed mode reproduces the recorded sequence year-by-year" do
+    run_in_tmp do |dir, writer|
+      silently { described_class.new(app_config, failed_runs_writer: writer).run }
+      saved_path = Dir.glob(File.join(dir, "run_*.yml")).first
+      saved = FailedRuns::Serializer.read(saved_path)
+      replay_inputs = inputs.merge(
+        "mode" => "detailed",
+        "return_sequence_type" => "recorded",
+        "recorded_sequence_file" => saved_path
+      )
+      replay_config = AppConfig.new(replay_inputs)
+      simulator_output = Simulation::Simulator.new(replay_config).run
+      simulator_output[:yearly_results].each do |row|
+        expect(row[:rate_of_return]).to eq(saved["return_sequence"][row[:age]])
+      end
+    end
+  end
+end

--- a/spec/lib/simulation/simulator_spec.rb
+++ b/spec/lib/simulation/simulator_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Simulation::Simulator do
         expect(yearly_results.last[:age]).to eq(69)
       end
 
+      it "exposes return_sequence with one entry per simulated age matching yearly :rate_of_return" do
+        return_sequence = simulation_output[:return_sequence]
+        expect(return_sequence).to be_a(Hash)
+        yearly_results.each do |row|
+          expect(return_sequence[row[:age]]).to eq(row[:rate_of_return])
+        end
+      end
+
       it "verifies withdrawals for age 65" do
         row = yearly_results.find { |r| r[:age] == 65 }
         expect(row).to match(


### PR DESCRIPTION
## Summary

- In `success_rate` mode, persist a reservoir-sampled set of up to 50 failed return sequences to `failed_runs/` alongside an `index.md` manifest. Each saved file holds the `{age => return}` map, an outcome summary, and a SHA256 digest of the inputs that produced it.
- Add a `recorded` return sequence type so `detailed` mode can replay any captured failure year-by-year through the existing printer and evaluator. Cross-field validation rejects `success_rate` + `recorded` (a deterministic sequence run 1000 times is meaningless). The validation moved out of `AppRunner#initialize` into a dedicated `AppConfigValidator` so construction has no side effects.
- On replay, the saved `inputs_digest` is compared against the current `inputs.yml` and a mismatch shows an informational note (not a block) — the mismatch is itself useful for "replay this exact sequence with different spending" experiments.
- `RecordedSequence` validates at construction that the file's age range covers the simulator's `(retirement_age..max_age)` iteration. Previously an out-of-range request fell through to a `nil` `@avg` and crashed several frames later in the withdrawal strategy with a confusing `NoMethodError` on `nil`; the new check fails at startup with a multi-line error pointing at the inputs.yml fields to adjust.
- Document age-aligned replay semantics in `docs/configuration.md`: replay is keyed by absolute age, so changing `retirement_age` replays a different *slice* of the captured sequence rather than shifting the same pattern in time.

## Test plan

- [ ] `bin/ci` passes (rubocop + rspec + main.rb in both modes)
- [ ] `ruby main.rb success_rate` produces `failed_runs/run_NNNN.yml` files plus `index.md`, capped at 50, with the directory wiped at the start of each run
- [ ] `ruby main.rb` with `return_sequence_type: recorded` and `recorded_sequence_file: failed_runs/run_NNNN.yml` replays that failure year-by-year through detailed mode
- [ ] Edit `inputs.yml` after capture (e.g. lower `desired_spending`) and replay → digest-mismatch note appears, run is not blocked
- [ ] Set `retirement_age` lower than the captured range or `max_age` higher than it → startup error names the file, the requested range, and the covered range
- [ ] Set `mode: success_rate` with `return_sequence_type: recorded` → startup error explains why this combination is invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)